### PR TITLE
Add Unset field marker type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.2] - 2023-06-28
+
+### Added
+
+- `Unset` marker type used to "mark" that an optional model field is by default
+  not set but also not required to construct the model (#1).
+- Added support for `Unset` marker type on `BaseModelDict` (#1).
+
+## [0.0.1] - 2023-06-21
+
+### Added
+
+- Initial release of `pydantic_dict` -- A pydantic model subclass that
+  implements Python's built-in dictionary interface.

--- a/README.md
+++ b/README.md
@@ -33,6 +33,41 @@ user.setdefault("last_active", "2023-01-01T19:56:10Z")
 del user["last_active"]
 ```
 
+**`Unset` marker type**
+
+The `Unset` marker type provides a way to "mark" that an optional model field
+is by default not set and is not required to construct the model. This enables
+more semantic usage of built-in dict methods like `get()` and `setdefault()`
+that can return or set a default value. Likewise, fields that are `Unset` are
+not considered to be members of a `BaseModelDict` dictionary (e.g.
+`"unset_field" not in model_dict`) and are not included in `__iter__()`,
+`keys()`, `values()`, or `len(model_dict)`. This feature is especially useful
+when refactoring existing code to use pydantic.
+
+**Example:**
+
+
+```python
+from pydantic_dict import BaseModelDict, Unset
+from typing import Optional
+
+class User(BaseModelDict):
+    id: int
+    name: str = "Jane Doe"
+    email: Optional[str] = Unset
+
+user = User(id=42)
+
+assert "email" not in user
+user["email"] # raises KeyError
+
+assert len(user) == 2
+assert set(user.keys()) == {"id", "name"}
+
+user.setdefault("email", f"{user.id}@service.com") # returns `42@service.com`
+assert "email" in user
+```
+
 ## Install
 
 ```shell

--- a/pydantic_dict/__init__.py
+++ b/pydantic_dict/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "0.0.1"
+__version__ = "0.0.2"
 
 from .base_model_dictionary import BaseModelDict, Unset

--- a/pydantic_dict/__init__.py
+++ b/pydantic_dict/__init__.py
@@ -1,3 +1,3 @@
 __version__ = "0.0.1"
 
-from .base_model_dictionary import BaseModelDict
+from .base_model_dictionary import BaseModelDict, Unset

--- a/pydantic_dict/_sentinel.py
+++ b/pydantic_dict/_sentinel.py
@@ -1,0 +1,6 @@
+class Sentinel:
+    def __copy__(self):
+        return self
+
+    def __deepcopy__(self, *_):
+        return self

--- a/pydantic_dict/base_model_dictionary.py
+++ b/pydantic_dict/base_model_dictionary.py
@@ -106,6 +106,27 @@ class BaseModelDict(BaseModel):
     class Config(BaseModel.Config):
         extra = Extra.allow
 
+    def __init_subclass__(cls) -> None:
+        cls._default_unset = frozenset(
+            name
+            for name, field in cls.__fields__.items()
+            if field.default_factory == _unset_sentinel_singleton
+        )
+        return super().__init_subclass__()
+
+    def __init__(self, **data: Any) -> None:
+        super().__init__(**data)
+
+        # filter fields that were set during __init__ by `Unset` by default.
+        self._unset = set(
+            field
+            for field in self._default_unset
+            if self.__dict__[field] == _unset_sentinel
+        )
+
+    def _field_unset(self, key: str) -> bool:
+        return key in self._unset
+
     def __contains__(self, key: str) -> bool:
         return key in self.__dict__
 

--- a/pydantic_dict/base_model_dictionary.py
+++ b/pydantic_dict/base_model_dictionary.py
@@ -1,12 +1,14 @@
-from pydantic import BaseModel, Extra, ValidationError
+from pydantic import BaseModel, Extra, PrivateAttr, ValidationError, Field
 from typing import (
     Any,
     ClassVar,
     Dict,
+    FrozenSet,
     ItemsView,
     Iterable,
     Iterator,
     KeysView,
+    Set,
     Tuple,
     TypeVar,
     ValuesView,
@@ -95,6 +97,11 @@ class BaseModelDict(BaseModel):
     """
 
     __SENTINEL: ClassVar[object] = object()
+    _default_unset: ClassVar[FrozenSet[str]]
+    """set of fields on a _subclass_ with default value, `Unset`"""
+
+    _unset: Set[str] = PrivateAttr(default_factory=set)
+    """set of fields on an _instance_ that _are_, currently, `Unset`"""
 
     class Config(BaseModel.Config):
         extra = Extra.allow

--- a/pydantic_dict/base_model_dictionary.py
+++ b/pydantic_dict/base_model_dictionary.py
@@ -19,11 +19,18 @@ from typing import Callable, Any, TypeVar
 from typing_extensions import ParamSpec
 
 from ._utils import getclsattr
+from ._sentinel import Sentinel
 from .exceptions import UnreachableException
 
 M = TypeVar("M", bound="BaseModelDict")
 P = ParamSpec("P")
 R = TypeVar("R", covariant=True)
+
+_unset_sentinel = Sentinel()
+
+
+def _unset_sentinel_singleton():
+    return _unset_sentinel
 
 
 def _raise_type_error_if_immutable(fn: Callable[P, R]) -> Callable[P, R]:
@@ -51,6 +58,9 @@ def _raise_value_error_if_extra_fields_not_allowed(m: BaseModel):
         raise UnreachableException()
     if extra != Extra.allow:
         raise ValueError(f'"{type(m).__name__}" does not allow extra fields.')
+
+
+Unset: None = Field(default_factory=_unset_sentinel_singleton)
 
 
 class BaseModelDict(BaseModel):

--- a/tests/test_unset.py
+++ b/tests/test_unset.py
@@ -1,0 +1,395 @@
+import pytest
+from pydantic import ValidationError
+from pydantic_dict import BaseModelDict, Unset
+from pydantic_dict.base_model_dictionary import _unset_sentinel
+
+from typing import Tuple, Optional
+from typing_extensions import TypeAlias
+
+FieldKey: TypeAlias = str
+DictKey: TypeAlias = str
+
+
+class KVModel(BaseModelDict):
+    key: str
+    unset_key: Optional[str] = Unset
+
+
+class KVModelWithFieldValidation(KVModel):
+    class Config(KVModel.Config):
+        validate_assignment = True
+
+
+class KVModelFrozen(KVModel):
+    class Config(KVModel.Config):
+        frozen = True
+
+
+class KVModelIgnoreExtra(KVModel):
+    class Config(KVModel.Config):
+        extra = "ignore"
+
+
+class KVModelForbidExtra(KVModel):
+    class Config(KVModel.Config):
+        extra = "forbid"
+
+
+DataRetType = Tuple[KVModel, FieldKey, FieldKey, DictKey]
+
+
+@pytest.fixture
+def data() -> DataRetType:
+    m = KVModel(key="value")
+    m["key2"] = "value2"
+
+    return m, "key", "unset_key", "key2"
+
+
+@pytest.fixture
+def data_with_validate_assignment() -> DataRetType:
+    m = KVModelWithFieldValidation(key="value")
+    m["key2"] = "value2"
+
+    return m, "key", "unset_key", "key2"
+
+
+@pytest.fixture
+def data_with_frozen_model() -> DataRetType:
+    m = KVModelFrozen(key="value", key2="value2")
+    return m, "key", "unset_key", "key2"
+
+
+@pytest.fixture
+def data_with_ignore_extras() -> DataRetType:
+    m = KVModelIgnoreExtra(key="value", key2="value2")
+    return m, "key", "unset_key", "key2"
+
+
+@pytest.fixture
+def data_with_forbid_extras() -> DataRetType:
+    m = KVModelForbidExtra(key="value")
+    return m, "key", "unset_key", "key2"
+
+
+def test___contains__(data: DataRetType):
+    model, field_key, unset_key, dict_key = data
+    assert field_key in model
+    assert unset_key not in model
+    assert dict_key in model
+
+    m1 = model.copy(deep=True)
+    m2 = model.copy(deep=True)
+
+    assert unset_key not in m1
+    assert unset_key not in m2
+
+    m1[unset_key] = "value"
+    assert unset_key in m1
+
+    m2.unset_key = "value"
+    assert unset_key in m2
+
+
+def test___delitem__(data: DataRetType):
+    model, field_key, unset_key, dict_key = data
+
+    del model[dict_key]
+    assert dict_key not in model
+
+    assert field_key in model
+    # cannot delete field key
+    with pytest.raises(KeyError):
+        del model[field_key]
+
+    # cannot delete unset field key
+    with pytest.raises(KeyError):
+        del model[unset_key]
+
+
+def test___eq__():
+    class D(BaseModelDict):
+        a: Optional[int] = None
+
+    class D2(BaseModelDict):
+        a: Optional[int] = Unset
+
+    m1 = D()
+    m2 = D2()
+    assert m1 != m2
+
+
+def test___getattribute__(data: DataRetType):
+    model, field_key, unset_key, dict_key = data
+
+    # testing that this does not raise
+    getattr(model, field_key)
+    getattr(model, unset_key)
+    getattr(model, dict_key)
+
+
+def test___getitem__(data: DataRetType):
+    model, field_key, unset_key, dict_key = data
+
+    # testing that this _does_ raise
+    with pytest.raises(KeyError):
+        model[unset_key]
+
+    # testing that these do not raise
+    model[field_key]
+    model[dict_key]
+
+
+def test___hash__():
+    class D(BaseModelDict):
+        c: Optional[int] = Unset
+
+        class Config(BaseModelDict.Config):
+            frozen = True
+
+    m1 = D(a=42, b=42)
+    m2 = D.fromkeys(["a", "b"], 42)
+    assert hash(m1) == hash(m2)
+
+    m3 = D(a=42, b=42, c=42)
+    assert hash(m1) != hash(m3)
+
+
+def test___iter__(data: DataRetType):
+    # test `unset_key` is not included in iter
+    model, field_key, unset_key, dict_key = data
+    assert set(iter(model)) == {field_key, dict_key}
+
+
+def test___len__(data: DataRetType):
+    model, _, _, _ = data
+    assert len(model) == 2
+    # test that _unset field is not counted in dictionary length
+    assert len(model) != len(model.__dict__)
+
+
+def test___setattr__(data: DataRetType):
+    model, field_key, unset_key, _ = data
+    setattr(model, field_key, "new_value")
+    setattr(model, unset_key, "new_value")
+
+
+def test___setitem__(data: DataRetType):
+    model, field_key, unset_key, dict_key = data
+    model[field_key] = "new_value"
+    assert model[field_key] == "new_value"
+
+    model[dict_key] = "new_value"
+    assert model[dict_key] == "new_value"
+
+    assert unset_key not in model
+    model[unset_key] = "new_value"
+
+
+def test_clear(data: DataRetType):
+    model, field_key, unset_key, dict_key = data
+    assert dict_key in model
+
+    # clear does not remove field keys
+    model.clear()
+    assert field_key in model
+    assert unset_key in model.__dict__
+    assert unset_key not in model
+    assert dict_key not in model
+
+
+def test_copy(data: DataRetType):
+    model, _, unset_key, _ = data
+    copy = model.copy()
+    assert copy == model
+    assert model._unset == copy._unset
+    assert model._default_unset == copy._default_unset
+
+    setattr(model, unset_key, "value")
+    copy = model.copy()
+    assert copy == model
+    assert model._unset == copy._unset
+    assert model._default_unset == copy._default_unset
+    assert model[unset_key] == "value"
+    assert copy[unset_key] == "value"
+
+
+def test_dict():
+    model = KVModel(key="value")
+    model["key2"] = "value2"
+    assert model.dict(exclude_unset=True) == dict(key="value", key2="value2")
+
+    assert model.dict() == dict(key="value", key2="value2", unset_key=_unset_sentinel)
+
+
+def test_fromkeys():
+    model_keys = ["key", "key2"]
+    model_value = "value"
+    model = KVModel.fromkeys(model_keys, model_value)
+
+    for key in model:
+        assert model[key] == model_value
+
+    assert len(model) == 2
+    assert len(model.__dict__) != 2
+
+
+def test_get():
+    model = KVModel(key="value", key2="value2")
+
+    # unset key returns default
+    assert model.get("unset_key") == None
+
+    # positive cases
+    assert model.get("key") == "value"
+    assert model.get("key2") == "value2"
+
+
+def test_items():
+    model = KVModel(key="value", key2="value2")
+
+    # collect key, value pairs into dictionary
+    collected_model = dict(model.items())
+
+    assert collected_model == dict(key="value", key2="value2")
+
+
+def test_json(data: DataRetType):
+    import json
+
+    model = KVModel(key="value", key2="value2")
+
+    with pytest.raises(TypeError):
+        assert model.json() == json.dumps(model.dict())
+
+    assert model.json(exclude_unset=True) == json.dumps(model.dict(exclude_unset=True))
+
+
+def test_keys():
+    model = KVModel(key="value", key2="value2")
+
+    assert set(model.keys()) == {"key", "key2"}
+
+    model.unset_key = "value"
+    assert set(model.keys()) == {"key", "key2", "unset_key"}
+
+
+def test_parse_obj(data: DataRetType):
+    model, _, _, _ = data
+    assert KVModel.parse_obj(model.dict(exclude_unset=True)) == model
+
+
+def test_parse_raw(data: DataRetType):
+    model, _, _, _ = data
+
+    assert model == KVModel.parse_raw(model.json(exclude_unset=True))
+
+
+def test_pop(data: DataRetType):
+    model, field_key, unset_key, dict_key = data
+
+    # cannot pop a field key
+    with pytest.raises(KeyError):
+        model.pop(field_key)
+
+    with pytest.raises(KeyError):
+        model.pop(unset_key)
+
+    # you can remove a dict_key
+    dict_key_value = model[dict_key]
+    assert dict_key_value == model.pop(dict_key)
+    assert dict_key not in model
+
+    # you should be able to return a non-default value for a non-existent key
+    assert False == model.pop("non_existent_key", False)
+
+
+def test_setdefault(data: DataRetType):
+    model, _, unset_key, _ = data
+
+    assert unset_key not in model
+    assert model.setdefault(unset_key, "value") == "value"
+
+    model_len = len(model)
+    assert model.setdefault("key3", "value3") == "value3"
+    assert len(model) == model_len + 1
+
+
+def test_update(data: DataRetType):
+    model, _, _, _ = data
+
+    assert "unset_key" not in model
+    more_testing_data = {"unset_key": "value"}
+    model.update(more_testing_data)
+    assert "unset_key" in model
+
+
+def test_values(data: DataRetType):
+    model = KVModel(key="value1", key2="value2")
+    assert list(model.values()) == ["value1", "value2"]
+
+    model.unset_key = "value3"
+    assert list(model.values()) == ["value1", "value2", "value3"]
+
+
+def test_update_with_validate_assignment(data_with_validate_assignment: DataRetType):
+    model, model_key, unset_key, _ = data_with_validate_assignment
+
+    pre_op_dict = model.__dict__.copy()
+    copy = model.copy()
+    deep_copy = model.copy(deep=True)
+
+    # force type validation error, cannot coerce a function type into a str
+    # unset_key should remain Unset
+    more_testing_data = {unset_key: lambda: 42}
+    with pytest.raises(ValidationError):
+        model.update(more_testing_data)
+
+    assert model == copy
+    assert model == deep_copy
+    assert pre_op_dict == model.__dict__
+
+
+def test_update_unsafe_with_validate_assignment(
+    data_with_validate_assignment: DataRetType,
+):
+    model, _, unset_key, _ = data_with_validate_assignment
+
+    more_testing_data = {unset_key: "value3"}
+    model.update_unsafe(more_testing_data)
+    assert unset_key in model
+    # ensure `unset_key` is removed from set of currently unset fields
+    assert unset_key not in model._unset
+
+
+def test_frozen_model_raises_on_mutation(data_with_frozen_model: DataRetType):
+    model, _, unset_key, _ = data_with_frozen_model
+
+    with pytest.raises(TypeError):
+        model.pop(unset_key)
+    with pytest.raises(TypeError):
+        model.setdefault(unset_key, "42")
+    with pytest.raises(TypeError):
+        setattr(model, unset_key, "42")
+    with pytest.raises(TypeError):
+        model[unset_key] = "42"
+
+    assert getattr(model, unset_key) == _unset_sentinel
+
+
+def test_modifying_field_data_with_ignore_extras_enabled(
+    data_with_ignore_extras: DataRetType,
+):
+    model, _, unset_key, _ = data_with_ignore_extras
+    model[unset_key] = "value2"
+    model.setdefault(unset_key, "value")
+    model.update({unset_key: "value2"})
+
+
+def test_modifying_field_data_with_forbid_extras_enabled(
+    data_with_forbid_extras: DataRetType,
+):
+    model, _, unset_key, _ = data_with_forbid_extras
+    model[unset_key] = "value2"
+    model.setdefault(unset_key, "value")
+    model.update({unset_key: "value2"})


### PR DESCRIPTION
Add Unset field marker type and functionality on `BaseModelDict`.

This type is used to "mark" that an optional model field is by default not set but also not required to construct the model. This enables more semantic usage of built-in dict methods like `get` and `setdefault` that _can_ return or set a default value. Likewise, `Unset` fields are not considered to be members of the dictionary (e.g. `"unset_field" not in model_dict`) and are not included in `__iter__()`, `keys()`, `values()`, or `len`.

Consider the following:

```python
class Foo(BaseModelDict):
    bar: Optional[int] = None

foo = Foo()

foo.get("bar", 42) # returns None
```

If you are in the process of refactoring a codebase to use pydantic, this would be extremely annoying and require extra refactoring work. Now with the feature:

```python
class Foo(BaseModelDict):
    bar: Optional[int] = Unset

foo = Foo()

assert "bar" not in foo
foo["bar"] # raises KeyError

foo.setdefault("bar", 42) # returns 42
assert "bar" in foo
```
