### PR TITLE
Pin pydantic<2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.0.3] - 2023-06-30
+
+## Changes
+
+- Pin `pydantic<2`. [Pydantic 2](https://pypi.org/project/pydantic/2.0/) was
+  released today. This major version release introduces some breaking changes
+  that will need to be addressed. Unlike pydantic, hopefully we can support v1
+  and v2 without breaking our api.
+
 ## [0.0.2] - 2023-06-28
 
 ### Added

--- a/pydantic_dict/__init__.py
+++ b/pydantic_dict/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "0.0.2"
+__version__ = "0.0.3"
 
 from .base_model_dictionary import BaseModelDict, Unset

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
   "Topic :: Utilities",
 ]
 dependencies = [
-  "pydantic",
+  "pydantic<2",
   "typing_extensions",
 ]
 description = "A pydantic model subclass that implements Python's dictionary interface."


### PR DESCRIPTION
Pin `pydantic<2`. [Pydantic 2](https://pypi.org/project/pydantic/2.0/) was released today. This major version release introduces some breaking changes that will need to be addressed. Unlike pydantic, hopefully we can support v1 and v2 without breaking our api.
